### PR TITLE
Fix user dropdown stacking and prevent text selection in user menu

### DIFF
--- a/browser/index-merged.html
+++ b/browser/index-merged.html
@@ -128,6 +128,7 @@
         .user-avatar:hover {
             transform: scale(1.1);
             box-shadow: 0 0 20px rgba(0, 255, 255, 0.5);
+            user-select: none;
         }
 
         /* Navigation Bar */
@@ -525,6 +526,8 @@
             .browser-header {
                 flex-direction: column;
                 gap: 15px;
+                position: relative;
+                z-index: 9999;
             }
             
             .nav-bar {
@@ -559,6 +562,7 @@
             min-width: 200px;
             z-index: 9999;
             display: none;
+            user-select: none;
         }
 
         .user-dropdown.active {


### PR DESCRIPTION
Raise `.browser-header` stacking context and prevent text selection.

- Updated `.browser-header` with `position: relative` and `z-index: 9999` to ensure the user dropdown appears above all other elements. 
- Added `user-select: none` to `.user-avatar:hover` and `.user-dropdown` to prevent accidental text selection in the user menu.

Before:
<img width="257" height="265" alt="Screenshot from 2025-08-01 17-31-40" src="https://github.com/user-attachments/assets/dcf04142-da50-4162-8ed2-8e29d8fe3697" />

After:
<img width="257" height="265" alt="Screenshot from 2025-08-01 17-31-27" src="https://github.com/user-attachments/assets/32da8bff-058b-48fe-afa1-e13528a3e82c" />
